### PR TITLE
fix: Update sorting to work better with null values

### DIFF
--- a/entgql/pagination.go
+++ b/entgql/pagination.go
@@ -222,23 +222,17 @@ func multiPredicate[T any](cursor *Cursor[T], opts *MultiCursorsOptions) (func(*
 		for i := range opts.Fields {
 			var ands []*sql.Predicate
 			for j := 0; j < i; j++ {
-				value := values[j]
-				if value == nil {
+				if values[j] == nil {
 					ands = append(ands, sql.IsNull(s.C(opts.Fields[j])))
 				} else {
 					ands = append(ands, sql.EQ(s.C(opts.Fields[j]), values[j]))
 				}
 			}
-			if values[i] == nil {
-				ands = append(ands, sql.IsNull(s.C(opts.Fields[i])))
+			if opts.Directions[i] == OrderDirectionAsc {
+				ands = append(ands, sql.GT(s.C(opts.Fields[i]), values[i]))
 			} else {
-				if opts.Directions[i] == OrderDirectionAsc {
-					ands = append(ands, sql.GT(s.C(opts.Fields[i]), values[i]))
-				} else {
-					ands = append(ands, sql.LT(s.C(opts.Fields[i]), values[i]))
-				}
+				ands = append(ands, sql.LT(s.C(opts.Fields[i]), values[i]))
 			}
-
 			or = append(or, sql.And(ands...))
 		}
 		s.Where(sql.Or(or...))

--- a/entgql/pagination.go
+++ b/entgql/pagination.go
@@ -222,13 +222,23 @@ func multiPredicate[T any](cursor *Cursor[T], opts *MultiCursorsOptions) (func(*
 		for i := range opts.Fields {
 			var ands []*sql.Predicate
 			for j := 0; j < i; j++ {
-				ands = append(ands, sql.EQ(s.C(opts.Fields[j]), values[j]))
+				value := values[j]
+				if value == nil {
+					ands = append(ands, sql.IsNull(s.C(opts.Fields[j])))
+				} else {
+					ands = append(ands, sql.EQ(s.C(opts.Fields[j]), values[j]))
+				}
 			}
-			if opts.Directions[i] == OrderDirectionAsc {
-				ands = append(ands, sql.GT(s.C(opts.Fields[i]), values[i]))
+			if values[i] == nil {
+				ands = append(ands, sql.IsNull(s.C(opts.Fields[i])))
 			} else {
-				ands = append(ands, sql.LT(s.C(opts.Fields[i]), values[i]))
+				if opts.Directions[i] == OrderDirectionAsc {
+					ands = append(ands, sql.GT(s.C(opts.Fields[i]), values[i]))
+				} else {
+					ands = append(ands, sql.LT(s.C(opts.Fields[i]), values[i]))
+				}
 			}
+
 			or = append(or, sql.And(ands...))
 		}
 		s.Where(sql.Or(or...))

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -333,7 +333,8 @@ func (p *{{ $pager }}) applyOrder(query *{{ $query }}) *{{ $query }} {
 			if p.reverse {
 				direction = direction.Reverse()
 			}
-			query = query.Order(o.Field.toTerm(direction.OrderTermOption()))
+      {{- /* TODO: Make this configurable somehow */}}
+			query = query.Order(o.Field.toTerm(direction.OrderTermOption(), sql.OrderNullsLast()))
 			if o.Field.column == {{ $defaultOrder }}.Field.column {
 				defaultOrdered = true
 			}
@@ -400,7 +401,8 @@ func (p *{{ $pager }}) orderExpr(query *{{ $node.QueryName }}) sql.Querier {
 					if p.reverse {
 						direction = direction.Reverse()
 					}
-					query = query.Order(o.Field.toTerm(direction.OrderTermOption()))
+      		{{- /* TODO: Make this configurable somehow */}}
+					query = query.Order(o.Field.toTerm(direction.OrderTermOption(), sql.OrderNullsLast()))
 				default:
 					{{- /* Ensure the cursor field is selected to encode it back to the client. */}}
 					if len(query.ctx.Fields) > 0 {


### PR DESCRIPTION
This adds `nulls last` to all order by statements. We'll want to make that configurable before putting up a PR for this fork, but for now this covers our use case. It may take some time to figure out how to make it configurable, but we can improve our sorting a ton even with the hard coded nulls last.

This PR also fixes a bug where null cursors were using `>` and `<` to compare against null which doesn't work as expected. You have to compare with `is null` or `is not null`.