### PR TITLE
fix: Allow empty where input

### DIFF
--- a/entgql/template/where_input.tmpl
+++ b/entgql/template/where_input.tmpl
@@ -204,8 +204,6 @@ import (
             }
         {{- end }}
         switch len(predicates) {
-        case 0:
-            return nil, {{ $err }}
         case 1:
             return predicates[0], nil
         default:


### PR DESCRIPTION
Delete the check that prevents an empty where predicate from being sent to Ent, removed it in the template so it won't generate for any entities' whereInput