### PR TITLE
feat: Support using enum names as graphql enum values

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -51,6 +51,10 @@ type (
 		QueryField *FieldConfig `json:"QueryField,omitempty"`
 		// MutationInputs defines the input types for the mutation.
 		MutationInputs []MutationConfig `json:"MutationInputs,omitempty"`
+		// UseEnumNames can be used on `Enum` fields that use the `NamedValues` function to specify values.
+		// when true, the graphql enums will use the Name instead of the value. This is useful when the value
+		// is something that is not a valid graphql enum
+		UseEnumNames bool `json:"UseEnumNames,omitempty"`
 	}
 
 	// Directive to apply on the field/type.
@@ -427,6 +431,10 @@ func Mutations(inputs ...MutationOption) Annotation {
 	return Annotation{MutationInputs: a}
 }
 
+func UseEnumNames() Annotation {
+	return Annotation{UseEnumNames: true}
+}
+
 // Merge implements the schema.Merger interface.
 func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	var ant Annotation
@@ -482,6 +490,7 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 		}
 		a.QueryField.merge(ant.QueryField)
 	}
+	a.UseEnumNames = ant.UseEnumNames
 	return a
 }
 

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -53,7 +53,7 @@ type (
 		MutationInputs []MutationConfig `json:"MutationInputs,omitempty"`
 		// UseEnumNames can be used on `Enum` fields that use the `NamedValues` function to specify values.
 		// when true, the graphql enums will use the Name instead of the value. This is useful when the value
-		// is something that is not a valid graphql enum
+		// is something that is not a valid graphql enum.
 		UseEnumNames bool `json:"UseEnumNames,omitempty"`
 	}
 

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -405,7 +405,7 @@ func (e *schemaGenerator) buildFieldEnum(f *gen.Field, gqlType, goType string) (
 	var name string
 	for _, v := range f.Enums {
 		if ant.UseEnumNames {
-			name = v.Name
+			name = strings.TrimPrefix(v.Name, f.StructField())
 		} else {
 			name = v.Value
 		}

--- a/entgql/schema.go
+++ b/entgql/schema.go
@@ -398,9 +398,19 @@ func (e *schemaGenerator) enumOrderByValues(t *gen.Type, gqlType string) (*ast.D
 
 func (e *schemaGenerator) buildFieldEnum(f *gen.Field, gqlType, goType string) (*ast.Definition, error) {
 	enumValues := make(ast.EnumValueList, 0, len(f.Enums))
+	ant, err := annotation(f.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	var name string
 	for _, v := range f.Enums {
+		if ant.UseEnumNames {
+			name = v.Name
+		} else {
+			name = v.Value
+		}
 		enumValues = append(enumValues, &ast.EnumValueDefinition{
-			Name: v.Value,
+			Name: name,
 		})
 	}
 	return &ast.Definition{

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -95,6 +95,7 @@ var (
 		"nodePaginationNames": nodePaginationNames,
 		"orderFields":         orderFields,
 		"skipMode":            skipModeFromString,
+		"trimPrefix":          trimPrefix,
 	}
 
 	//go:embed template/*
@@ -552,6 +553,10 @@ func skipModeFromString(modes ...string) (SkipMode, error) {
 		}
 	}
 	return m, nil
+}
+
+func trimPrefix(source, prefix string) string {
+	return strings.TrimPrefix(source, prefix)
 }
 
 func isSkipMode(antSkip interface{}, m string) (bool, error) {

--- a/entgql/template/enum.tmpl
+++ b/entgql/template/enum.tmpl
@@ -14,10 +14,28 @@ in the LICENSE file in the root directory of this source tree.
 
 {{ range $f := $.EnumFields }}
 	{{ $enum := trimPackage $f.Type.String $.Package -}}
+	{{ $useEnumNames := $f.Annotations.EntGQL.UseEnumNames -}}
 	{{- if not $f.HasGoType }}
+		{{- if $useEnumNames }}
+			var {{ $f.Name }}GqlEnumToTypeMap = map[string]{{ $enum }} {
+			{{- range $e := $f.Enums }}
+				"{{ trimPrefix $e.Name $f.StructField }}": {{ $e.Name }},
+			{{ end }}
+			}
+
+			var {{ $f.Name }}TypeToGqlEnum = map[{{ $enum }}]string {
+			{{- range $e := $f.Enums }}
+				{{ $e.Name }}: "{{ trimPrefix $e.Name $f.StructField }}",
+			{{ end }}
+			}
+		{{- end }}
 		// MarshalGQL implements graphql.Marshaler interface.
 		func (e {{ $enum }}) MarshalGQL(w io.Writer) {
+			{{- if $useEnumNames }}
+			io.WriteString(w, strconv.Quote({{ $f.Name }}TypeToGqlEnum[e]))
+			{{- else }}
 			io.WriteString(w, strconv.Quote(e.String()))
+			{{- end }}
 		}
 
 		// UnmarshalGQL implements graphql.Unmarshaler interface.
@@ -26,7 +44,15 @@ in the LICENSE file in the root directory of this source tree.
 			if !ok {
 				return fmt.Errorf("enum %T must be a string", val)
 			}
+			{{- if $useEnumNames }}
+			{{ $f.Name }}, ok := {{ $f.Name }}GqlEnumToTypeMap[str]
+			if !ok {
+				return fmt.Errorf("%s is not a valid {{ $enum }}", str)
+			}
+			*e = {{ $f.Name }}
+			{{- else }}
 			*e = {{ $enum }}(str)
+			{{- end }}
 			if err := {{ $f.Validator }}(*e); err != nil {
 				return fmt.Errorf("%s is not a valid {{ $enum }}", str)
 			}

--- a/entgql/template/enum.tmpl
+++ b/entgql/template/enum.tmpl
@@ -20,13 +20,13 @@ in the LICENSE file in the root directory of this source tree.
 			var {{ $f.Name }}GqlEnumToTypeMap = map[string]{{ $enum }} {
 			{{- range $e := $f.Enums }}
 				"{{ trimPrefix $e.Name $f.StructField }}": {{ $e.Name }},
-			{{ end }}
+			{{- end }}
 			}
 
 			var {{ $f.Name }}TypeToGqlEnum = map[{{ $enum }}]string {
 			{{- range $e := $f.Enums }}
 				{{ $e.Name }}: "{{ trimPrefix $e.Name $f.StructField }}",
-			{{ end }}
+			{{- end }}
 			}
 		{{- end }}
 		// MarshalGQL implements graphql.Marshaler interface.


### PR DESCRIPTION
This PR adds the capability to use enum names as graphql enums. This is useful when you have pre-existing data that is an enum that isn't a valid graphql enum. Using `field.Enum().NamedValues()` the `name` part of the named values is used as the graphql enum, allowing for something like this
```Go
field.Enum("my_enum").NamedValues("INVALID_GRAPHQL_ENUM", "invalid-graphql-enum").Annotations(entgql.UseEnumNames())
```
Which will generate a graphql spec like this
```graphql
enum MyEnum {
  INVALID_GRAPHQL_ENUM
}
```
And generate graphql unmarshal and marshal methods that convert between the graphql enum, and the go enum type.

This is accomplished by using a new annotation `UseEnumNames`

This is backwards compatible because you have to opt in via the new annotation.