### PR TITLE
fix: UseEnumNames merge behavior

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -490,7 +490,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 		}
 		a.QueryField.merge(ant.QueryField)
 	}
-	a.UseEnumNames = ant.UseEnumNames
+	if a.UseEnumNames {
+		a.UseEnumNames = true
+	}
 	return a
 }
 


### PR DESCRIPTION
UseEnumNames was simply setting it's value in each iteration of the `Merge()` method call, resulting in order mattering. This changes the implementation to match other booleans, only set a value if true.