### PR TITLE
fix: comparison typo in UseEnumNames merge

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -490,7 +490,7 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 		}
 		a.QueryField.merge(ant.QueryField)
 	}
-	if a.UseEnumNames {
+	if ant.UseEnumNames {
 		a.UseEnumNames = true
 	}
 	return a


### PR DESCRIPTION
don't compare against itself, compare against input.

working quickly and didn't realize the typo. apologies.