### PR TITLE
fix: nulls direction default when paginating with multiple predicates

### DIFF
--- a/entgql/pagination.go
+++ b/entgql/pagination.go
@@ -302,6 +302,9 @@ func multiPredicate[T any](cursor *Cursor[T], opts *MultiCursorsOptions) (func(*
 					ands = append(ands, sql.EQ(s.C(column), values[j]))
 				}
 			}
+			if opts.NullsDirections[i] == "" {
+    		opts.NullsDirections[i] = NullsLast
+			}
 			if opts.Directions[i] == OrderDirectionAsc {
 				switch {
 				case values[i] == nil && opts.NullsDirections[i] == NullsFirst:


### PR DESCRIPTION
I forgot to default nullsDirection on multiPredicate, which is called first when you paginate with many conditions: cursor and orderBy + stuff, so it was skipping all the switch cases when a nullsDirection wasn't provided(default case) by the FE