### PR TITLE
feat: add named enums to graphql description, add deprecation directives

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -53,8 +53,12 @@ type (
 		MutationInputs []MutationConfig `json:"MutationInputs,omitempty"`
 		// UseEnumNames can be used on `Enum` fields that use the `NamedValues` function to specify values.
 		// when true, the graphql enums will use the Name instead of the value. This is useful when the value
-		// is something that is not a valid graphql enum.
+		// is something that is not a valid graphql enum. The value will be added to the description of the
+		// resulting enum in the graphql schema.
 		UseEnumNames bool `json:"UseEnumNames,omitempty"`
+		// DeprecatedEnumValues is a list of enum values that should be marked
+		// with the `@deprecated` directive.
+		DeprecatedEnumValues []string `json:"DeprecatedEnumValues,omitempty"`
 	}
 
 	// Directive to apply on the field/type.
@@ -435,6 +439,10 @@ func UseEnumNames() Annotation {
 	return Annotation{UseEnumNames: true}
 }
 
+func DeprecatedEnumValues(values ...string) Annotation {
+	return Annotation{DeprecatedEnumValues: values}
+}
+
 // Merge implements the schema.Merger interface.
 func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	var ant Annotation
@@ -492,6 +500,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if ant.UseEnumNames {
 		a.UseEnumNames = true
+	}
+	if len(ant.DeprecatedEnumValues) > 0 {
+		a.DeprecatedEnumValues = append(a.DeprecatedEnumValues, ant.DeprecatedEnumValues...)
 	}
 	return a
 }


### PR DESCRIPTION
extends the existing UseEnumNames functionality to add the enum values to the description of the graphql schema. This allows for clients of the graphql schema to be aware of the values of the enums. Useful for converting an enum to a nice display value without needing to manually maintain a separate mapping from enum to display value.

adds a new `DeprecatedEnumValues` annotation. This allows for specifying an array of enum values that should have the "deprecated" directive added in the graphql schema.

in combination, these allow for a better client experience.