### PR TITLE
fix(entgql): restore split-package generation compatibility

### DIFF
--- a/entgql/extension.go
+++ b/entgql/extension.go
@@ -593,6 +593,9 @@ func (e *Extension) generateSplitGoFiles(g *gen.Graph) error {
 			name := name
 			entityInputs := entityInputs
 			fns = append(fns, func() error { return e.generateMutationInputFile(&staged, name, entityInputs) })
+			// Also generate SetInput methods in the entity sub-package to avoid circular imports.
+			// Uses the real g (not staged) since sub-package dirs are created by ent, not the staging system.
+			fns = append(fns, func() error { return e.generateMutationInputSubpkgFile(g, name, entityInputs) })
 		}
 	}
 
@@ -860,6 +863,41 @@ func (e *Extension) generateWhereInputFile(g *gen.Graph, n *gen.Type) error {
 	content, err := e.processImports(path, buf.Bytes())
 	if err != nil {
 		return fmt.Errorf("entgql: format where_input for %s: %w", n.Name, err)
+	}
+
+	return os.WriteFile(path, content, 0644)
+}
+
+// generateMutationInputSubpkgFile generates SetInput methods in the entity's sub-package
+// (e.g., src/ent/gen/agentlicensing/gql_mutation_input.go). These methods must live in the
+// sub-package because Go does not allow method declarations on types from other packages.
+// A local interface breaks the circular import that would arise if the sub-package imported
+// the root gen package for the concrete input types.
+func (e *Extension) generateMutationInputSubpkgFile(g *gen.Graph, name string, inputs []*MutationDescriptor) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	entityType := inputs[0].Type
+	subPkgDir := filepath.Join(g.Target, entityType.Package())
+	if _, err := os.Stat(subPkgDir); os.IsNotExist(err) {
+		return nil // sub-package doesn't exist, skip
+	}
+
+	path := filepath.Join(subPkgDir, "gql_mutation_input.go")
+
+	tmpl := MutationInputSubpkgTemplate
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct {
+		*gen.Graph
+		EntityName string
+		Inputs     []*MutationDescriptor
+	}{g, name, inputs}); err != nil {
+		return fmt.Errorf("entgql: execute mutation_input_subpkg template for %s: %w", name, err)
+	}
+
+	content, err := e.processImports(path, buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("entgql: format mutation_input_subpkg for %s: %w", name, err)
 	}
 
 	return os.WriteFile(path, content, 0644)

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -74,6 +74,11 @@ var (
 	// Initialized in init() to avoid initialization order issues.
 	MutationInputEntityTemplate *template.Template
 
+	// MutationInputSubpkgTemplate generates SetInput methods in the entity sub-package to avoid
+	// circular imports between the root gen package and entity sub-packages (used in split mode).
+	// Initialized in init() to avoid initialization order issues.
+	MutationInputSubpkgTemplate *template.Template
+
 	// PaginationEntityTemplate generates pagination code for a single entity (used in split mode).
 	// Initialized in init() to avoid initialization order issues.
 	PaginationEntityTemplate *template.Template
@@ -169,6 +174,7 @@ func init() {
 	// Initialize entity templates after all vars are set up
 	WhereInputEntityTemplate = parseEntityTemplate("template/where_input_entity.tmpl", "gql_where_input_entity")
 	MutationInputEntityTemplate = parseEntityTemplate("template/mutation_input_entity.tmpl", "gql_mutation_input_entity")
+	MutationInputSubpkgTemplate = parseEntityTemplate("template/mutation_input_subpkg.tmpl", "gql_mutation_input_subpkg")
 	PaginationEntityTemplate = parseEntityTemplate("template/pagination_entity.tmpl", "gql_pagination_entity")
 	PaginationSharedTemplate = parseEntityTemplate("template/pagination_shared.tmpl", "gql_pagination_shared")
 	CollectionSharedTemplate = parseEntityTemplate("template/collection_shared.tmpl", "gql_collection_shared")

--- a/entgql/template/collection.tmpl
+++ b/entgql/template/collection.tmpl
@@ -63,7 +63,7 @@ func ({{ $receiver }} *{{ $query }}) collectField(ctx context.Context, oneNode b
 						var (
 							alias = field.Alias
 							path  = append(path, alias)
-							query = (&{{ $e.Type.ClientName }}{config: {{ $receiver }}.config}).Query()
+							query = (&{{ $e.Type.ClientName }}{Config: {{ $receiver }}.Config}).Query()
 						)
 						{{- if isRelayConn $e }}
 							{{- $tnames := nodePaginationNames $e.Type }}
@@ -284,13 +284,65 @@ const (
 )
 
 func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]any {
+	if args := parsedFieldArgs(ctx, path...); args != nil {
+		return unmarshalArgs(ctx, whereInput, args)
+	}
 	field := collectedField(ctx, path...)
 	if field == nil || field.Arguments == nil {
 		return nil
 	}
 	oc := graphql.GetOperationContext(ctx)
+	if oc == nil {
+		return nil
+	}
 	args := field.ArgumentMap(oc.Variables)
 	return unmarshalArgs(ctx, whereInput, args)
+}
+
+func parsedFieldArgs(ctx context.Context, path ...string) map[string]any {
+	fc := graphql.GetFieldContext(ctx)
+	if fc == nil {
+		return nil
+	}
+	if len(path) == 0 {
+		return cloneArgsMap(fc.Args)
+	}
+	oc := graphql.GetOperationContext(ctx)
+	if oc == nil {
+		return nil
+	}
+
+walk:
+	for _, name := range path {
+		if fc.Child == nil {
+			return nil
+		}
+		for _, field := range graphql.CollectFields(oc, fc.Field.Selections, nil) {
+			if field.Alias != name {
+				continue
+			}
+			child, err := fc.Child(ctx, field)
+			if err != nil || child == nil {
+				return nil
+			}
+			fc = child
+			continue walk
+		}
+		return nil
+	}
+
+	return cloneArgsMap(fc.Args)
+}
+
+func cloneArgsMap(args map[string]any) map[string]any {
+	if args == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(args))
+	for k, v := range args {
+		cloned[k] = v
+	}
+	return cloned
 }
 
 // unmarshalArgs allows extracting the field arguments from their raw representation.

--- a/entgql/template/collection_entity.tmpl
+++ b/entgql/template/collection_entity.tmpl
@@ -65,7 +65,7 @@ func ({{ $receiver }} *{{ $query }}) collectField(ctx context.Context, oneNode b
 						var (
 							alias = field.Alias
 							path  = append(path, alias)
-							query = (&{{ $e.Type.ClientName }}{config: {{ $receiver }}.config}).Query()
+							query = (&{{ $e.Type.ClientName }}{Config: {{ $receiver }}.Config}).Query()
 						)
 						{{- if isRelayConn $e }}
 							{{- $tnames := nodePaginationNames $e.Type }}

--- a/entgql/template/collection_shared.tmpl
+++ b/entgql/template/collection_shared.tmpl
@@ -25,13 +25,65 @@ const (
 )
 
 func fieldArgs(ctx context.Context, whereInput any, path ...string) map[string]any {
+	if args := parsedFieldArgs(ctx, path...); args != nil {
+		return unmarshalArgs(ctx, whereInput, args)
+	}
 	field := collectedField(ctx, path...)
 	if field == nil || field.Arguments == nil {
 		return nil
 	}
 	oc := graphql.GetOperationContext(ctx)
+	if oc == nil {
+		return nil
+	}
 	args := field.ArgumentMap(oc.Variables)
 	return unmarshalArgs(ctx, whereInput, args)
+}
+
+func parsedFieldArgs(ctx context.Context, path ...string) map[string]any {
+	fc := graphql.GetFieldContext(ctx)
+	if fc == nil {
+		return nil
+	}
+	if len(path) == 0 {
+		return cloneArgsMap(fc.Args)
+	}
+	oc := graphql.GetOperationContext(ctx)
+	if oc == nil {
+		return nil
+	}
+
+walk:
+	for _, name := range path {
+		if fc.Child == nil {
+			return nil
+		}
+		for _, field := range graphql.CollectFields(oc, fc.Field.Selections, nil) {
+			if field.Alias != name {
+				continue
+			}
+			child, err := fc.Child(ctx, field)
+			if err != nil || child == nil {
+				return nil
+			}
+			fc = child
+			continue walk
+		}
+		return nil
+	}
+
+	return cloneArgsMap(fc.Args)
+}
+
+func cloneArgsMap(args map[string]any) map[string]any {
+	if args == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(args))
+	for k, v := range args {
+		cloned[k] = v
+	}
+	return cloned
 }
 
 // unmarshalArgs allows extracting the field arguments from their raw representation.

--- a/entgql/template/edge_entity.tmpl
+++ b/entgql/template/edge_entity.tmpl
@@ -65,16 +65,6 @@ import (
 			return FromContext(ctx).{{ $node.Name }}.Query{{ $e.StructField }}({{ $r }}).Paginate(ctx, after, first, before, last, opts...)
 		}
 
-		func ({{ $r }} *{{ $node.Name }}) {{ $e.StructField }}(
-			ctx context.Context, after *Cursor, first *int, before *Cursor, last *int,
-			{{- if orderFields $e.Type }}orderBy {{ if $multiOrder }}[]{{ end }}*{{ $order }},{{ end }}
-			{{- if and $.HasWhereInputTemplate (hasWhereInput $e) }}where *{{ $whereInput }},{{ end }}
-		) (*{{ $conn }}, error) {
-			return Resolve{{ $node.Name }}{{ $e.StructField }}({{ $r }}, ctx, after, first, before, last,
-				{{- if orderFields $e.Type }}orderBy,{{ end }}
-				{{- if and $.HasWhereInputTemplate (hasWhereInput $e) }}where,{{ end }}
-			)
-		}
 	{{ else if not $e.Unique }}
 		// Resolve{{ $node.Name }}{{ $e.StructField }} resolves the {{ $e.Name }} edge of a {{ $node.Name }}.
 		func Resolve{{ $node.Name }}{{ $e.StructField }}({{ $r }} *{{ $node.Name }}, ctx context.Context) (result []*{{ $e.Type.Name }}, err error) {
@@ -90,9 +80,6 @@ import (
 			return result, err
 		}
 
-		func ({{ $r }} *{{ $node.Name }}) {{ $e.StructField }}(ctx context.Context) ([]*{{ $e.Type.Name }}, error) {
-			return Resolve{{ $node.Name }}{{ $e.StructField }}({{ $r }}, ctx)
-		}
 	{{ else }}
 		// Resolve{{ $node.Name }}{{ $e.StructField }} resolves the {{ $e.Name }} edge of a {{ $node.Name }}.
 		func Resolve{{ $node.Name }}{{ $e.StructField }}({{ $r }} *{{ $node.Name }}, ctx context.Context) (*{{ $e.Type.Name }}, error) {
@@ -103,9 +90,6 @@ import (
 			return result, {{ if $e.Optional }}MaskNotFound(err){{ else }}err{{ end }}
 		}
 
-		func ({{ $r }} *{{ $node.Name }}) {{ $e.StructField }}(ctx context.Context) (*{{ $e.Type.Name }}, error) {
-			return Resolve{{ $node.Name }}{{ $e.StructField }}({{ $r }}, ctx)
-		}
 	{{ end }}
 {{ end }}
 

--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -64,7 +64,7 @@ import (
     }
 
     // Mutate applies the {{ $input }} on the {{ $n.MutationName }} builder.
-    func (i *{{ $input }}) Mutate(m *{{ $n.MutationName }}) {
+    func (i {{ $input }}) Mutate(m *{{ $n.MutationName }}) {
         {{- /* The order of the operators is purposefully sorted: Clear, Set and Append */}}
         {{- range $f := $fields }}
             {{- if $f.ClearOp }}
@@ -126,7 +126,7 @@ import (
 
     {{- range $b := $n.Builders }}
     // Set{{ $b }}Input applies the change-set in the {{ $input }} on the {{ $b }} builder.
-    func Set{{ $b }}Input(c *{{ $b }}, i {{ $input }}) *{{ $b }} {
+    func Set{{ $b }}Input(c *{{ $n.Package }}.{{ $b }}, i {{ $input }}) *{{ $n.Package }}.{{ $b }} {
         i.Mutate(c.Mutation())
         return c
     }

--- a/entgql/template/mutation_input_entity.tmpl
+++ b/entgql/template/mutation_input_entity.tmpl
@@ -64,7 +64,7 @@ import (
     }
 
     // Mutate applies the {{ $input }} on the {{ $n.MutationName }} builder.
-    func (i *{{ $input }}) Mutate(m *{{ $n.MutationName }}) {
+    func (i {{ $input }}) Mutate(m *{{ $n.MutationName }}) {
         {{- /* The order of the operators is purposefully sorted: Clear, Set and Append */}}
         {{- range $f := $fields }}
             {{- if $f.ClearOp }}
@@ -121,15 +121,11 @@ import (
 
     {{- range $b := $n.Builders }}
     // Set{{ $b }}Input applies the change-set in the {{ $input }} on the {{ $b }} builder.
-    func Set{{ $b }}Input(c *{{ $b }}, i {{ $input }}) *{{ $b }} {
+    func Set{{ $b }}Input(c *{{ $n.Package }}.{{ $b }}, i {{ $input }}) *{{ $n.Package }}.{{ $b }} {
         i.Mutate(c.Mutation())
         return c
     }
 
-    // SetInput applies the change-set in the {{ $input }} on the {{ $b }} builder.
-    func (c *{{ $b }}) SetInput(i {{ $input }}) *{{ $b }} {
-        return Set{{ $b }}Input(c, i)
-    }
     {{- end}}
 {{- end }}
 {{ end }}

--- a/entgql/template/mutation_input_subpkg.tmpl
+++ b/entgql/template/mutation_input_subpkg.tmpl
@@ -1,0 +1,31 @@
+{{/*
+Copyright 2019-present Facebook Inc. All rights reserved.
+This source code is licensed under the Apache 2.0 license found
+in the LICENSE file in the root directory of this source tree.
+*/}}
+
+{{ define "gql_mutation_input_subpkg" }}
+
+{{- /*gotype: entgo.io/contrib/entgql.mutationInputEntityData*/ -}}
+
+{{ $.Config.Header }}
+
+package {{ (index $.Inputs 0).Type.Package }}
+
+// mutationInput is a local interface to avoid circular imports between this
+// sub-package and the root gen package which holds the concrete input types.
+type mutationInput interface {
+	Mutate(*{{ (index $.Inputs 0).MutationName }})
+}
+
+{{- range $n := $.Inputs }}
+{{- range $b := $n.Builders }}
+// SetInput applies the change-set in the {{ $n.Input }} on the {{ $b }} builder.
+func (c *{{ $b }}) SetInput(i mutationInput) *{{ $b }} {
+	i.Mutate(c.Mutation())
+	return c
+}
+
+{{- end}}
+{{- end }}
+{{ end }}

--- a/entgql/template_test.go
+++ b/entgql/template_test.go
@@ -335,7 +335,7 @@ func TestCollectionSharedTemplateContent(t *testing.T) {
 	require.Contains(t, src, "func mayAddCondition")
 
 	// Verify NO per-entity code is present.
-	require.NotContains(t, src, "CollectFields")
+	require.NotContains(t, src, "CollectFields tells the query-builder")
 	require.NotContains(t, src, "collectField")
 	require.NotContains(t, src, "PaginateArgs")
 	require.NotContains(t, src, "newPaginateArg")
@@ -376,11 +376,16 @@ func TestCollectionSharedTemplateExecution(t *testing.T) {
 
 	// Verify shared functions are generated.
 	require.Contains(t, output, "func fieldArgs(")
+	require.Contains(t, output, "func parsedFieldArgs(")
+	require.Contains(t, output, "func cloneArgsMap(")
 	require.Contains(t, output, "func unmarshalArgs(")
 	require.Contains(t, output, "func mayAddCondition(")
+	require.Contains(t, output, "parsedFieldArgs(ctx, path...)")
+	require.Contains(t, output, "child, err := fc.Child(ctx, field)")
+	require.Contains(t, output, "return cloneArgsMap(fc.Args)")
 
 	// Verify NO per-entity code is present.
-	require.False(t, strings.Contains(output, "CollectFields"),
+	require.False(t, strings.Contains(output, "CollectFields tells the query-builder"),
 		"shared template should not generate per-entity CollectFields method")
 	require.False(t, strings.Contains(output, "collectField"),
 		"shared template should not generate per-entity collectField method")
@@ -408,9 +413,9 @@ func TestPaginationEntityTemplateContent(t *testing.T) {
 
 	// Verify per-entity types are present (template source uses {{$edge}}, {{$conn}} etc.).
 	// In the parsed tree, template vars are rendered as {{$varname}}.
-	require.Contains(t, src, "}} struct")       // Edge/Connection struct declarations
-	require.Contains(t, src, "PaginateOption")  // PaginateOption type
-	require.Contains(t, src, "OrderField")      // OrderField struct
+	require.Contains(t, src, "}} struct")      // Edge/Connection struct declarations
+	require.Contains(t, src, "PaginateOption") // PaginateOption type
+	require.Contains(t, src, "OrderField")     // OrderField struct
 
 	// Verify per-entity methods are present.
 	require.Contains(t, src, "Paginate")


### PR DESCRIPTION
## Summary
- add split-package mutation-input subpackage generation (`gql_mutation_input.go`) so builder `.SetInput(...)` methods are emitted where the builder types actually live
- update split collection argument parsing to prefer `FieldContext` child traversal (`parsedFieldArgs`) and safely clone arg maps for nested relay filters
- align split templates with current generated query/config layout (`Config` field usage) and keep mutation input helper signatures compatible across ent versions

## Test Plan
- go test ./entgql/... -count=1