### PR TITLE
feat(entgql): expression-aware ORDER BY + cursor predicates

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -27,6 +27,11 @@ type (
 	Annotation struct {
 		// OrderField is the ordering field as defined in graphql schema.
 		OrderField []string `json:"OrderField,omitempty"`
+		// OrderFieldExpr is an optional SQL expression used in ORDER BY and cursor
+		// predicates instead of the raw column. When set, generated code uses
+		// this expression so a matching expression index can be used by the planner
+		// (e.g. left("name", 256) for a (left("name", 256), id) btree).
+		OrderFieldExpr string `json:"OrderFieldExpr,omitempty"`
 		// MultiOrder indicates that orderBy should accept a list of OrderField terms.
 		MultiOrder bool `json:"MultiOrder,omitempty"`
 		// Unbind implies the edge field name in GraphQL schema is not equivalent
@@ -143,6 +148,24 @@ func (Annotation) Name() string {
 //		)
 func OrderField(fields ...string) Annotation {
 	return Annotation{OrderField: fields}
+}
+
+// OrderFieldExpr attaches a SQL expression to an ordering field so generated
+// ORDER BY and cursor predicates emit the expression instead of the raw column.
+// Pair it with OrderField on the same schema field:
+//
+//	field.String("name").
+//		SchemaType(map[string]string{dialect.Postgres: "text"}).
+//		Annotations(
+//			entgql.OrderField("NAME"),
+//			entgql.OrderFieldExpr(`left("name", 256)`),
+//		)
+//
+// This matches a composite index of the form (left("name", 256), id) and lets
+// the planner use it for cursor-based pagination on unbounded text columns
+// that would otherwise overflow the btree max tuple size.
+func OrderFieldExpr(expr string) Annotation {
+	return Annotation{OrderFieldExpr: expr}
 }
 
 // MultiOrder indicates that orderBy should accept a list of OrderField terms.
@@ -464,6 +487,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if len(ant.OrderField) > 0 {
 		a.OrderField = ant.OrderField
+	}
+	if ant.OrderFieldExpr != "" {
+		a.OrderFieldExpr = ant.OrderFieldExpr
 	}
 	if ant.MultiOrder {
 		a.MultiOrder = true

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -38,6 +38,25 @@ func TestAnnotation(t *testing.T) {
 	require.ElementsMatch(t, names, annotation.Mapping)
 }
 
+func TestOrderFieldExpr(t *testing.T) {
+	t.Parallel()
+	a := entgql.OrderFieldExpr(`left("name", 256)`)
+	require.Equal(t, `left("name", 256)`, a.OrderFieldExpr)
+	require.Empty(t, a.OrderField, "OrderFieldExpr should not set OrderField on its own")
+}
+
+func TestOrderFieldExprMerge(t *testing.T) {
+	t.Parallel()
+	// Pair OrderField with OrderFieldExpr on the same field via Merge,
+	// matching how schema callers attach them: two annotations in the
+	// same .Annotations(...) call.
+	merged := entgql.OrderField("NAME").Merge(entgql.OrderFieldExpr(`left("name", 256)`))
+	ann, ok := merged.(entgql.Annotation)
+	require.True(t, ok, "merged annotation should be entgql.Annotation, got %T", merged)
+	require.Equal(t, []string{"NAME"}, ann.OrderField)
+	require.Equal(t, `left("name", 256)`, ann.OrderFieldExpr)
+}
+
 func TestAnnotationDecode(t *testing.T) {
 	ann := &entgql.Annotation{}
 	err := ann.Decode(map[string]interface{}{})

--- a/entgql/cursors_predicate_expr_test.go
+++ b/entgql/cursors_predicate_expr_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package entgql_test
+
+import (
+	"testing"
+
+	"entgo.io/contrib/entgql"
+	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/sql"
+	"github.com/stretchr/testify/require"
+)
+
+// applyPredicates runs predicates against a fresh Postgres-dialect selector
+// and returns the SQL text + bound args. Using Postgres dialect to match
+// our target deployment and make assertions stable.
+func applyPredicates(t *testing.T, table string, preds []func(s *sql.Selector)) (string, []interface{}) {
+	t.Helper()
+	s := sql.Dialect(dialect.Postgres).Select("id").From(sql.Table(table))
+	for _, p := range preds {
+		p(s)
+	}
+	sqlText, args := s.Query()
+	return sqlText, args
+}
+
+func TestCursorsPredicateExpr_AfterValueAscEmitsExpression(t *testing.T) {
+	t.Parallel()
+	after := &entgql.Cursor[string]{ID: "id-2", Value: "alpha"}
+	preds := entgql.CursorsPredicateExpr(after, nil, "id", `left("name", 256)`, entgql.OrderDirectionAsc)
+	require.Len(t, preds, 1)
+
+	sqlText, args := applyPredicates(t, "contacts", preds)
+	require.Contains(t, sqlText, `left("name", 256) > $1`)
+	require.Contains(t, sqlText, `left("name", 256) = $2`)
+	require.Contains(t, sqlText, `"contacts"."id" > $3`)
+	require.Equal(t, []interface{}{"alpha", "alpha", "id-2"}, args)
+}
+
+func TestCursorsPredicateExpr_BeforeValueDescEmitsLessThan(t *testing.T) {
+	t.Parallel()
+	before := &entgql.Cursor[string]{ID: "id-5", Value: "zulu"}
+	preds := entgql.CursorsPredicateExpr(nil, before, "id", `left("name", 256)`, entgql.OrderDirectionDesc)
+	require.Len(t, preds, 1)
+
+	sqlText, _ := applyPredicates(t, "contacts", preds)
+	require.Contains(t, sqlText, `left("name", 256) < $1`)
+	require.Contains(t, sqlText, `"contacts"."id" < $3`)
+}
+
+func TestCursorsPredicateExpr_NilValueFallsBackToIDComparison(t *testing.T) {
+	t.Parallel()
+	// Cursors with nil Value (e.g. when ordering by ID itself) should
+	// behave identically to CursorsPredicate: just an ID comparison, no
+	// expression substitution.
+	after := &entgql.Cursor[string]{ID: "id-7"}
+	preds := entgql.CursorsPredicateExpr(after, nil, "id", `left("name", 256)`, entgql.OrderDirectionAsc)
+	require.Len(t, preds, 1)
+
+	sqlText, args := applyPredicates(t, "contacts", preds)
+	require.NotContains(t, sqlText, "left(", "no expression substitution when cursor has nil Value")
+	require.Contains(t, sqlText, `"id"`)
+	require.Equal(t, []interface{}{"id-7"}, args)
+}
+
+func TestCursorsPredicateExpr_NilCursorsProduceNoPredicates(t *testing.T) {
+	t.Parallel()
+	preds := entgql.CursorsPredicateExpr[string](nil, nil, "id", `left("name", 256)`, entgql.OrderDirectionAsc)
+	require.Empty(t, preds)
+}
+
+func TestCursorsPredicateExpr_BothBoundsAppendInOrder(t *testing.T) {
+	t.Parallel()
+	after := &entgql.Cursor[string]{ID: "id-2", Value: "alpha"}
+	before := &entgql.Cursor[string]{ID: "id-9", Value: "omega"}
+	preds := entgql.CursorsPredicateExpr(after, before, "id", `left("name", 256)`, entgql.OrderDirectionAsc)
+	require.Len(t, preds, 2)
+}

--- a/entgql/pagination.go
+++ b/entgql/pagination.go
@@ -219,6 +219,60 @@ func CursorsPredicate[T any](after, before *Cursor[T], idField, field string, di
 	return predicates
 }
 
+// CursorsPredicateExpr is the expression-aware variant of CursorsPredicate.
+// The expr argument is a raw SQL expression (e.g. `left("name", 256)`) that
+// substitutes for the ordering column in the cursor comparison, so an
+// expression-based composite index like (left("name", 256), id) can be used.
+//
+// The idField is still passed as a column name and qualified with the
+// selector's table alias. The cursor predicate emitted is logically:
+//
+//	expr > cursor.Value OR (expr = cursor.Value AND id > cursor.ID)
+//
+// (with `<` for descending). For cursors with no value, only the ID
+// comparison is emitted, identical to CursorsPredicate.
+func CursorsPredicateExpr[T any](after, before *Cursor[T], idField, expr string, direction OrderDirection) []func(s *sql.Selector) {
+	var predicates []func(s *sql.Selector)
+	for _, cursor := range []*Cursor[T]{after, before} {
+		if cursor == nil {
+			continue
+		}
+		if cursor.Value != nil {
+			cmp := ">"
+			if direction != OrderDirectionAsc {
+				cmp = "<"
+			}
+			// Scope the cursor of the current iteration because it is used
+			// in the closure below.
+			cursor := cursor
+			predicates = append(predicates, func(s *sql.Selector) {
+				s.Where(sql.P(func(b *sql.Builder) {
+					b.WriteString("(").
+						WriteString(expr).
+						WriteString(" ").WriteString(cmp).WriteString(" ").
+						Arg(cursor.Value).
+						WriteString(" OR (").
+						WriteString(expr).
+						WriteString(" = ").
+						Arg(cursor.Value).
+						WriteString(" AND ").
+						Ident(s.C(idField)).
+						WriteString(" ").WriteString(cmp).WriteString(" ").
+						Arg(cursor.ID).
+						WriteString("))")
+				}))
+			})
+		} else {
+			if direction == OrderDirectionAsc {
+				predicates = append(predicates, sql.FieldGT(idField, cursor.ID))
+			} else {
+				predicates = append(predicates, sql.FieldLT(idField, cursor.ID))
+			}
+		}
+	}
+	return predicates
+}
+
 // MultiCursorOptions are the options for building the cursor predicates.
 type MultiCursorsOptions struct {
 	FieldID         string           // ID field name.

--- a/entgql/template.go
+++ b/entgql/template.go
@@ -512,6 +512,16 @@ type OrderTerm struct {
 	Edge *gen.Edge
 	// True if it is a count field.
 	Count bool
+	// Expression, if non-empty, is a raw SQL expression substituted for the
+	// raw column name in ORDER BY and cursor predicate emission. Only valid
+	// for IsFieldTerm orderings.
+	Expression string
+}
+
+// HasExpression reports whether the term carries a SQL expression override
+// for ORDER BY and cursor predicates.
+func (o *OrderTerm) HasExpression() bool {
+	return o.Expression != ""
 }
 
 // IsFieldTerm returns true if the order term is a type field term.
@@ -586,10 +596,11 @@ func orderFields(n *gen.Type) ([]*OrderTerm, error) {
 			}
 			if len(ant.OrderField) == 1 {
 				terms = append(terms, &OrderTerm{
-					Owner: n,
-					GQL:   ant.OrderField[0],
-					Type:  n,
-					Field: f,
+					Owner:      n,
+					GQL:        ant.OrderField[0],
+					Type:       n,
+					Field:      f,
+					Expression: ant.OrderFieldExpr,
 				})
 			}
 		}

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -332,7 +332,13 @@ func (p *{{ $pager }}) applyCursors(query *{{ $query }}, after, before *Cursor) 
 		if p.reverse {
 			direction = direction.Reverse()
 		}
-		for _, predicate := range entgql.CursorsPredicate(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.column, direction) {
+		var predicates []func(s *sql.Selector)
+		if p.order.Field.expression != "" {
+			predicates = entgql.CursorsPredicateExpr(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.expression, direction)
+		} else {
+			predicates = entgql.CursorsPredicate(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.column, direction)
+		}
+		for _, predicate := range predicates {
 			query = query.Where(predicate)
 		}
 	{{- end }}
@@ -449,7 +455,12 @@ func (p *{{ $pager }}) orderExpr(query *{{ $node.QueryName }}) sql.Querier {
 					direction = direction.Reverse()
 					nullsDirection = nullsDirection.Reverse()
 				}
-				b.Ident(o.Field.column).Pad().WriteString(string(direction))
+				if o.Field.expression != "" {
+					b.WriteString(o.Field.expression)
+				} else {
+					b.Ident(o.Field.column)
+				}
+				b.Pad().WriteString(string(direction))
 				b.Pad().WriteString("NULLS").Pad().WriteString(string(nullsDirection))
 				b.Comma()
 			}
@@ -485,7 +496,12 @@ func (p *{{ $pager }}) orderExpr(query *{{ $node.QueryName }}) sql.Querier {
 			}
 		{{- end }}
 		return sql.ExprFunc(func(b *sql.Builder) {
-			b.Ident(p.order.Field.column).Pad().WriteString(string(direction))
+			if p.order.Field.expression != "" {
+				b.WriteString(p.order.Field.expression)
+			} else {
+				b.Ident(p.order.Field.column)
+			}
+			b.Pad().WriteString(string(direction))
 			b.Pad().WriteString("NULLS").Pad().WriteString(string(nullsDirection))
 			if p.order.Field != {{ $defaultOrder }}.Field {
 				b.Comma().Ident({{ $defaultOrder }}.Field.column).Pad().WriteString(string(direction))
@@ -524,7 +540,27 @@ func ({{ $r }} *{{ $query }}) Paginate(
 				},
 				{{- if $f.IsFieldTerm }}
 					column: {{ $node.Package }}.{{ $f.Field.Constant }},
+					{{- if $f.HasExpression }}
+					expression: `{{ $f.Expression }}`,
+					toTerm: func(opts ...sql.OrderTermOption) {{ $node.Package }}.OrderOption {
+						o := sql.NewOrderTermOptions(opts...)
+						return func(s *sql.Selector) {
+							s.OrderExprFunc(func(b *sql.Builder) {
+								b.WriteString(`{{ $f.Expression }}`)
+								if o.Desc {
+									b.WriteString(" DESC")
+								}
+								if o.NullsFirst {
+									b.WriteString(" NULLS FIRST")
+								} else if o.NullsLast {
+									b.WriteString(" NULLS LAST")
+								}
+							})
+						}
+					},
+					{{- else }}
 					toTerm: {{ $node.Package }}.{{ $f.Field.OrderName }},
+					{{- end }}
         {{- else if $f.IsNonUniqueEdgeFieldTerm }}
 					column: {{ $f.VarField }},
 					toTerm: func(opts ...sql.OrderTermOption) {{ $node.Package }}.OrderOption {
@@ -660,10 +696,16 @@ func ({{ $r }} *{{ $query }}) Paginate(
 // {{ $orderField }} defines the ordering field of {{ $node.Name }}.
 type {{ $orderField }} struct {
 	// Value extracts the ordering value from the given {{ $node.Name }}.
-	Value    func(*{{ $name }}) (ent.Value, error)
-	column   string // field or computed.
-	toTerm   func(...sql.OrderTermOption) {{ $node.Package }}.OrderOption
-	toCursor func(*{{ $name }}) Cursor
+	Value func(*{{ $name }}) (ent.Value, error)
+	// column is the raw column name. Used for SELECT field inclusion so the
+	// cursor value can be read back from each row.
+	column string
+	// expression, when non-empty, is a SQL expression used in ORDER BY and
+	// cursor comparisons instead of column (e.g. `left("name", 256)`).
+	// See entgql.OrderFieldExpr.
+	expression string
+	toTerm     func(...sql.OrderTermOption) {{ $node.Package }}.OrderOption
+	toCursor   func(*{{ $name }}) Cursor
 }
 
 // {{ $order }} defines the ordering of {{ $node.Name }}.

--- a/entgql/template/pagination_entity.tmpl
+++ b/entgql/template/pagination_entity.tmpl
@@ -242,7 +242,13 @@ func (p *{{ $pager }}) applyCursors(query *{{ $query }}, after, before *Cursor) 
 		if p.reverse {
 			direction = direction.Reverse()
 		}
-		for _, predicate := range entgql.CursorsPredicate(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.column, direction) {
+		var predicates []func(s *sql.Selector)
+		if p.order.Field.expression != "" {
+			predicates = entgql.CursorsPredicateExpr(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.expression, direction)
+		} else {
+			predicates = entgql.CursorsPredicate(after, before, {{ $defaultOrder }}.Field.column, p.order.Field.column, direction)
+		}
+		for _, predicate := range predicates {
 			query = query.Where(predicate)
 		}
 	{{- end }}
@@ -359,7 +365,12 @@ func (p *{{ $pager }}) orderExpr(query *{{ $node.QueryName }}) sql.Querier {
 					direction = direction.Reverse()
 					nullsDirection = nullsDirection.Reverse()
 				}
-				b.Ident(o.Field.column).Pad().WriteString(string(direction))
+				if o.Field.expression != "" {
+					b.WriteString(o.Field.expression)
+				} else {
+					b.Ident(o.Field.column)
+				}
+				b.Pad().WriteString(string(direction))
 				b.Pad().WriteString("NULLS").Pad().WriteString(string(nullsDirection))
 				b.Comma()
 			}
@@ -395,7 +406,12 @@ func (p *{{ $pager }}) orderExpr(query *{{ $node.QueryName }}) sql.Querier {
 			}
 		{{- end }}
 		return sql.ExprFunc(func(b *sql.Builder) {
-			b.Ident(p.order.Field.column).Pad().WriteString(string(direction))
+			if p.order.Field.expression != "" {
+				b.WriteString(p.order.Field.expression)
+			} else {
+				b.Ident(p.order.Field.column)
+			}
+			b.Pad().WriteString(string(direction))
 			b.Pad().WriteString("NULLS").Pad().WriteString(string(nullsDirection))
 			if p.order.Field != {{ $defaultOrder }}.Field {
 				b.Comma().Ident({{ $defaultOrder }}.Field.column).Pad().WriteString(string(direction))
@@ -481,7 +497,27 @@ func ({{ $r }} *{{ $query }}) Paginate(
 				},
 				{{- if $f.IsFieldTerm }}
 					column: {{ $node.Package }}.{{ $f.Field.Constant }},
+					{{- if $f.HasExpression }}
+					expression: `{{ $f.Expression }}`,
+					toTerm: func(opts ...sql.OrderTermOption) {{ $node.Package }}.OrderOption {
+						o := sql.NewOrderTermOptions(opts...)
+						return func(s *sql.Selector) {
+							s.OrderExprFunc(func(b *sql.Builder) {
+								b.WriteString(`{{ $f.Expression }}`)
+								if o.Desc {
+									b.WriteString(" DESC")
+								}
+								if o.NullsFirst {
+									b.WriteString(" NULLS FIRST")
+								} else if o.NullsLast {
+									b.WriteString(" NULLS LAST")
+								}
+							})
+						}
+					},
+					{{- else }}
 					toTerm: {{ $node.Package }}.{{ $f.Field.OrderName }},
+					{{- end }}
         {{- else if $f.IsNonUniqueEdgeFieldTerm }}
 					column: {{ $f.VarField }},
 					toTerm: func(opts ...sql.OrderTermOption) {{ $node.Package }}.OrderOption {
@@ -617,10 +653,16 @@ func ({{ $r }} *{{ $query }}) Paginate(
 // {{ $orderField }} defines the ordering field of {{ $node.Name }}.
 type {{ $orderField }} struct {
 	// Value extracts the ordering value from the given {{ $node.Name }}.
-	Value    func(*{{ $name }}) (ent.Value, error)
-	column   string // field or computed.
-	toTerm   func(...sql.OrderTermOption) {{ $node.Package }}.OrderOption
-	toCursor func(*{{ $name }}) Cursor
+	Value func(*{{ $name }}) (ent.Value, error)
+	// column is the raw column name. Used for SELECT field inclusion so the
+	// cursor value can be read back from each row.
+	column string
+	// expression, when non-empty, is a SQL expression used in ORDER BY and
+	// cursor comparisons instead of column (e.g. `left("name", 256)`).
+	// See entgql.OrderFieldExpr.
+	expression string
+	toTerm     func(...sql.OrderTermOption) {{ $node.Package }}.OrderOption
+	toCursor   func(*{{ $name }}) Cursor
 }
 
 // {{ $order }} defines the ordering of {{ $node.Name }}.


### PR DESCRIPTION
## Summary

Adds an optional `OrderFieldExpr` annotation that swaps a SQL expression for the raw column in ORDER BY emission and cursor comparisons. Motivated by composite indexes of the form `(left("col", 256), id)` — needed for cursor-based pagination on unbounded text columns that would otherwise overflow Postgres' 2704-byte btree max tuple size. The left-expression index only helps if the query also uses the same expression; this PR teaches entgql how to emit it.

## New surface

- `entgql.OrderFieldExpr("left(\"name\", 256)")` — schema annotation paired with `entgql.OrderField` on the same field.
- `entgql.CursorsPredicateExpr` — variant of `CursorsPredicate` that compares against a raw SQL expression instead of a quoted column.
- Generated `<Entity>OrderField` struct gains an `expression` string field. When set, ORDER BY emission writes the expression raw and `toTerm` calls `sql.OrderExprFunc` instead of ent's `By<Field>` helper. `column` is kept for SELECT list inclusion so cursor values can still be read back per row.

Templates updated for both monolithic (`pagination.tmpl`) and entity-split (`pagination_entity.tmpl`) generation modes. **Behavior is unchanged for any field that doesn't carry `OrderFieldExpr`** — the existing column path is preserved.

## Why this is needed

Postgres btree indexes have a 2704-byte max tuple size. A composite `(description, id)` index on an unbounded `text` column fails to build the moment a row's `description` exceeds that. A `(left("description", 256), id)` index sidesteps the limit, but `ORDER BY description, id` won't use it — the planner needs an exact expression match. Without this PR, users either skip indexing those columns (slow sort) or build indexes that no query can use.

## Test plan

- [x] All existing entgql tests pass (`go test ./...`)
- [x] New unit tests for `CursorsPredicateExpr` covering ASC/DESC, nil-value cursors (ID-only fallback), and nil-cursor inputs
- [x] New unit tests for `OrderFieldExpr` annotation and Merge behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)