### PR TITLE
feat(entgql): API surface for WithIndexOutput (annotation + options, no hook)

### DIFF
--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -45,6 +45,9 @@ type (
 		Type string `json:"Type,omitempty"`
 		// Skip exclude the type
 		Skip SkipMode `json:"Skip,omitempty"`
+		// SkipIndex controls which index variants the WithIndexOutput writer
+		// emits for this field. See SkipIndexMode.
+		SkipIndex SkipIndexMode `json:"SkipIndex,omitempty"`
 		// RelayConnection enables the Relay Connection specification for the entity.
 		// It's also can apply on an edge to create the Relay-style filter.
 		RelayConnection bool `json:"RelayConnection,omitempty"`
@@ -118,6 +121,32 @@ const (
 		SkipMutationCreateInput |
 		SkipMutationUpdateInput
 )
+
+// SkipIndexMode is a bit flag for the SkipIndex annotation. It controls which
+// classes of index the WithIndexOutput writer emits for a field.
+type SkipIndexMode int
+
+const (
+	// SkipIndexOrder skips the composite (col, id) btree pagination index
+	// for fields annotated with OrderField.
+	SkipIndexOrder SkipIndexMode = 1 << iota
+	// SkipIndexEquality skips the plain (col) btree index for fields exposed
+	// in WhereInput with EQ/NEQ/In predicates.
+	SkipIndexEquality
+	// SkipIndexContains skips the GIN trigram index for fields exposed in
+	// WhereInput with Contains/HasPrefix/HasSuffix predicates.
+	SkipIndexContains
+
+	// SkipAllIndexes is the default mode when SkipIndex() is called with no
+	// arguments — skips every index variant for the annotated field.
+	SkipAllIndexes = SkipIndexOrder | SkipIndexEquality | SkipIndexContains
+)
+
+// Any reports whether any index-skip flag is set.
+func (m SkipIndexMode) Any() bool { return m != 0 }
+
+// Is reports whether m contains the given mode flag.
+func (m SkipIndexMode) Is(mode SkipIndexMode) bool { return m&mode != 0 }
 
 // Name implements ent.Annotation interface.
 func (Annotation) Name() string {
@@ -273,6 +302,26 @@ func Skip(flags ...SkipMode) Annotation {
 		skip |= f
 	}
 	return Annotation{Skip: skip}
+}
+
+// SkipIndex returns an annotation that opts a field out of index generation
+// by the WithIndexOutput writer. Pass specific modes to skip a subset; pass
+// no args to skip all index variants.
+//
+//	field.Float("commission").
+//	    Annotations(
+//	        entgql.OrderField("COMMISSION"),
+//	        entgql.SkipIndex(entgql.SkipIndexOrder), // view-computed; no base table column
+//	    )
+func SkipIndex(modes ...SkipIndexMode) Annotation {
+	if len(modes) == 0 {
+		return Annotation{SkipIndex: SkipAllIndexes}
+	}
+	var mask SkipIndexMode
+	for _, m := range modes {
+		mask |= m
+	}
+	return Annotation{SkipIndex: mask}
 }
 
 // RelayConnection returns an annotation indicating that the node/edge should support pagination.
@@ -505,6 +554,9 @@ func (a Annotation) Merge(other schema.Annotation) schema.Annotation {
 	}
 	if ant.Skip.Any() {
 		a.Skip |= ant.Skip
+	}
+	if ant.SkipIndex.Any() {
+		a.SkipIndex |= ant.SkipIndex
 	}
 	if len(ant.MutationInputs) > 0 {
 		a.MutationInputs = append(a.MutationInputs, ant.MutationInputs...)

--- a/entgql/annotation.go
+++ b/entgql/annotation.go
@@ -78,6 +78,10 @@ type (
 	// SkipMode is a bit flag for the Skip annotation.
 	SkipMode int
 
+	// SkipIndexMode is a bit flag for the SkipIndex annotation. It controls which
+	// classes of index the WithIndexOutput writer emits for a field.
+	SkipIndexMode int
+
 	FieldConfig struct {
 		// Name is the name of the field in the Query object.
 		Name string `json:"Name,omitempty"`
@@ -122,10 +126,6 @@ const (
 		SkipMutationUpdateInput
 )
 
-// SkipIndexMode is a bit flag for the SkipIndex annotation. It controls which
-// classes of index the WithIndexOutput writer emits for a field.
-type SkipIndexMode int
-
 const (
 	// SkipIndexOrder skips the composite (col, id) btree pagination index
 	// for fields annotated with OrderField.
@@ -141,12 +141,6 @@ const (
 	// arguments — skips every index variant for the annotated field.
 	SkipAllIndexes = SkipIndexOrder | SkipIndexEquality | SkipIndexContains
 )
-
-// Any reports whether any index-skip flag is set.
-func (m SkipIndexMode) Any() bool { return m != 0 }
-
-// Is reports whether m contains the given mode flag.
-func (m SkipIndexMode) Is(mode SkipIndexMode) bool { return m&mode != 0 }
 
 // Name implements ent.Annotation interface.
 func (Annotation) Name() string {
@@ -601,6 +595,16 @@ func (f SkipMode) Any() bool {
 
 // Is checks if the skip annotation has a specific flag.
 func (f SkipMode) Is(mode SkipMode) bool {
+	return f&mode != 0
+}
+
+// Any reports whether any index-skip flag is set.
+func (f SkipIndexMode) Any() bool {
+	return f != 0
+}
+
+// Is reports whether f contains the given mode flag.
+func (f SkipIndexMode) Is(mode SkipIndexMode) bool {
 	return f&mode != 0
 }
 

--- a/entgql/annotation_test.go
+++ b/entgql/annotation_test.go
@@ -80,3 +80,54 @@ func TestAnnotationDecode(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "json: cannot unmarshal string into Go value of type entgql.Annotation")
 }
+
+func TestSkipIndex_NoArgs_SkipsAll(t *testing.T) {
+	t.Parallel()
+	a := entgql.SkipIndex()
+	require.Equal(t, entgql.SkipAllIndexes, a.SkipIndex)
+}
+
+func TestSkipIndex_SingleMode(t *testing.T) {
+	t.Parallel()
+	a := entgql.SkipIndex(entgql.SkipIndexOrder)
+	require.Equal(t, entgql.SkipIndexOrder, a.SkipIndex)
+	require.True(t, a.SkipIndex.Is(entgql.SkipIndexOrder))
+	require.False(t, a.SkipIndex.Is(entgql.SkipIndexEquality))
+	require.False(t, a.SkipIndex.Is(entgql.SkipIndexContains))
+}
+
+func TestSkipIndex_MultiMode_OrFolded(t *testing.T) {
+	t.Parallel()
+	a := entgql.SkipIndex(entgql.SkipIndexOrder, entgql.SkipIndexContains)
+	require.True(t, a.SkipIndex.Is(entgql.SkipIndexOrder))
+	require.True(t, a.SkipIndex.Is(entgql.SkipIndexContains))
+	require.False(t, a.SkipIndex.Is(entgql.SkipIndexEquality))
+}
+
+func TestSkipIndexMode_Any(t *testing.T) {
+	t.Parallel()
+	require.False(t, entgql.SkipIndexMode(0).Any())
+	require.True(t, entgql.SkipIndexOrder.Any())
+	require.True(t, entgql.SkipAllIndexes.Any())
+}
+
+func TestAnnotationMerge_SkipIndex_OrFolds(t *testing.T) {
+	t.Parallel()
+	a := entgql.SkipIndex(entgql.SkipIndexOrder)
+	b := entgql.SkipIndex(entgql.SkipIndexEquality)
+	merged := a.Merge(b).(entgql.Annotation)
+	require.True(t, merged.SkipIndex.Is(entgql.SkipIndexOrder))
+	require.True(t, merged.SkipIndex.Is(entgql.SkipIndexEquality))
+	require.False(t, merged.SkipIndex.Is(entgql.SkipIndexContains))
+}
+
+func TestAnnotationDecode_SkipIndex(t *testing.T) {
+	t.Parallel()
+	ann := &entgql.Annotation{}
+	err := ann.Decode(map[string]interface{}{
+		"SkipIndex": int(entgql.SkipIndexOrder | entgql.SkipIndexContains),
+	})
+	require.NoError(t, err)
+	require.True(t, ann.SkipIndex.Is(entgql.SkipIndexOrder))
+	require.True(t, ann.SkipIndex.Is(entgql.SkipIndexContains))
+}

--- a/entgql/extension.go
+++ b/entgql/extension.go
@@ -58,9 +58,9 @@ type (
 		// Index DDL output (see WithIndexOutput / WithIndexTableNameStrip /
 		// WithIndexSoftDeleteColumn). The writer hook is conditionally
 		// appended in NewExtension when indexOutputPath != "".
-		indexOutputPath        string
-		indexTableNameStrip    *regexp.Regexp
-		indexSoftDeleteColumn  string
+		indexOutputPath       string
+		indexTableNameStrip   *regexp.Regexp
+		indexSoftDeleteColumn string
 	}
 
 	// ExtensionOption allows for managing the Extension configuration

--- a/entgql/extension.go
+++ b/entgql/extension.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 
@@ -53,6 +54,13 @@ type (
 		parallelWhereInputFiles bool   // opt-in parallel generation for where-input split files
 		importsDir              string // real target dir for imports.Process path resolution during split generation
 		maxPageSize             int    // server-side default and cap for connection pagination
+
+		// Index DDL output (see WithIndexOutput / WithIndexTableNameStrip /
+		// WithIndexSoftDeleteColumn). The writer hook is conditionally
+		// appended in NewExtension when indexOutputPath != "".
+		indexOutputPath        string
+		indexTableNameStrip    *regexp.Regexp
+		indexSoftDeleteColumn  string
 	}
 
 	// ExtensionOption allows for managing the Extension configuration
@@ -307,6 +315,7 @@ func NewExtension(opts ...ExtensionOption) (*Extension, error) {
 			relaySpec:    true,
 			genMutations: true,
 		},
+		indexSoftDeleteColumn: "deleted_at",
 	}
 	for _, opt := range opts {
 		if err := opt(ex); err != nil {

--- a/entgql/extension_indexes.go
+++ b/entgql/extension_indexes.go
@@ -1,0 +1,77 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entgql
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// WithIndexOutput configures entgql to emit a deterministic SQL file containing
+// CREATE INDEX statements that match the queries the generated GraphQL surface
+// invites (ORDER BY, WhereInput predicates).
+//
+// path is the absolute or relative file path to write. Empty path (the default)
+// disables emission and no writer hook is added to the extension.
+//
+// The generated file is regenerated on every entgql run and should be checked
+// into version control alongside the schema. Sort order is deterministic
+// (tables alphabetical, indexes alphabetical by field within table) so
+// regenerations produce minimal diffs.
+//
+// Per-field opt-out via the entgql.SkipIndex annotation.
+func WithIndexOutput(path string) ExtensionOption {
+	return func(ex *Extension) error {
+		ex.indexOutputPath = path
+		return nil
+	}
+}
+
+// WithIndexTableNameStrip configures a regular expression whose matches in
+// node.Table() are removed when computing the physical table name for index
+// emission. Use this when ent entities are backed by views but indexes
+// target the underlying base table.
+//
+//	entgql.WithIndexTableNameStrip("_view$")
+//
+// Empty pattern (the default) disables stripping. An invalid regex returns
+// an error at option-apply time.
+func WithIndexTableNameStrip(pattern string) ExtensionOption {
+	return func(ex *Extension) error {
+		if pattern == "" {
+			ex.indexTableNameStrip = nil
+			return nil
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("entgql: WithIndexTableNameStrip: invalid pattern %q: %w", pattern, err)
+		}
+		ex.indexTableNameStrip = re
+		return nil
+	}
+}
+
+// WithIndexSoftDeleteColumn names the column whose presence on an entity
+// triggers partial-index emission ("WHERE <col> IS NULL"). Default:
+// "deleted_at". Empty string disables partial-index emission entirely.
+//
+// Match is by StorageKey() on any field of the entity; the column does
+// not need to be exposed in the GraphQL schema.
+func WithIndexSoftDeleteColumn(col string) ExtensionOption {
+	return func(ex *Extension) error {
+		ex.indexSoftDeleteColumn = col
+		return nil
+	}
+}

--- a/entgql/extension_indexes.go
+++ b/entgql/extension_indexes.go
@@ -39,15 +39,18 @@ func WithIndexOutput(path string) ExtensionOption {
 	}
 }
 
-// WithIndexTableNameStrip configures a regular expression whose matches in
-// node.Table() are removed when computing the physical table name for index
-// emission. Use this when ent entities are backed by views but indexes
-// target the underlying base table.
+// WithIndexTableNameStrip configures a regular expression whose full-match
+// substrings are deleted from node.Table() when computing the physical table
+// name for index emission. Use this when ent entities are backed by views
+// but indexes target the underlying base table.
 //
 //	entgql.WithIndexTableNameStrip("_view$")
+//	// node.Table() = "escrows_view"   -> index target = "escrows"
+//	// node.Table() = "sync_positions" -> index target = "sync_positions" (unchanged)
 //
 // Empty pattern (the default) disables stripping. An invalid regex returns
-// an error at option-apply time.
+// an error at option-apply time, so misconfiguration fails fast during
+// NewExtension rather than during codegen.
 func WithIndexTableNameStrip(pattern string) ExtensionOption {
 	return func(ex *Extension) error {
 		if pattern == "" {
@@ -65,7 +68,9 @@ func WithIndexTableNameStrip(pattern string) ExtensionOption {
 
 // WithIndexSoftDeleteColumn names the column whose presence on an entity
 // triggers partial-index emission ("WHERE <col> IS NULL"). Default:
-// "deleted_at". Empty string disables partial-index emission entirely.
+// "deleted_at". Empty string disables partial-index emission entirely —
+// there is no fallback to the default, so pass "deleted_at" explicitly
+// to restore the default after disabling.
 //
 // Match is by StorageKey() on any field of the entity; the column does
 // not need to be exposed in the GraphQL schema.

--- a/entgql/extension_indexes_test.go
+++ b/entgql/extension_indexes_test.go
@@ -1,0 +1,103 @@
+// Copyright 2019-present Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entgql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewExtension_DefaultIndexOptions(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension()
+	require.NoError(t, err)
+	require.Empty(t, ex.indexOutputPath)
+	require.Nil(t, ex.indexTableNameStrip)
+	require.Equal(t, "deleted_at", ex.indexSoftDeleteColumn)
+}
+
+func TestWithIndexOutput_SetsPath(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(WithIndexOutput("out/indexes.sql"))
+	require.NoError(t, err)
+	require.Equal(t, "out/indexes.sql", ex.indexOutputPath)
+}
+
+func TestWithIndexOutput_EmptyDisables(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(WithIndexOutput(""))
+	require.NoError(t, err)
+	require.Empty(t, ex.indexOutputPath)
+}
+
+func TestWithIndexTableNameStrip_ValidPattern(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(WithIndexTableNameStrip("_view$"))
+	require.NoError(t, err)
+	require.NotNil(t, ex.indexTableNameStrip)
+	require.Equal(t, "escrows", ex.indexTableNameStrip.ReplaceAllString("escrows_view", ""))
+	require.Equal(t, "escrows_archived", ex.indexTableNameStrip.ReplaceAllString("escrows_archived", ""))
+}
+
+func TestWithIndexTableNameStrip_EmptyResetsToNil(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(
+		WithIndexTableNameStrip("_view$"),
+		WithIndexTableNameStrip(""),
+	)
+	require.NoError(t, err)
+	require.Nil(t, ex.indexTableNameStrip)
+}
+
+func TestWithIndexTableNameStrip_InvalidPattern_Errors(t *testing.T) {
+	t.Parallel()
+	_, err := NewExtension(WithIndexTableNameStrip("[invalid"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WithIndexTableNameStrip")
+}
+
+func TestWithIndexSoftDeleteColumn_Override(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(WithIndexSoftDeleteColumn("removed_at"))
+	require.NoError(t, err)
+	require.Equal(t, "removed_at", ex.indexSoftDeleteColumn)
+}
+
+func TestWithIndexSoftDeleteColumn_EmptyDisables(t *testing.T) {
+	t.Parallel()
+	ex, err := NewExtension(WithIndexSoftDeleteColumn(""))
+	require.NoError(t, err)
+	require.Empty(t, ex.indexSoftDeleteColumn)
+}
+
+func TestIndexOptions_HooksUnchanged(t *testing.T) {
+	t.Parallel()
+	// Baseline: no index options.
+	baseline, err := NewExtension()
+	require.NoError(t, err)
+	baselineHooks := len(baseline.Hooks())
+
+	// All three index options set, but no writer hook is wired in this PR.
+	// Hook count must NOT change — that arrives in the next PR.
+	ex, err := NewExtension(
+		WithIndexOutput("out/indexes.sql"),
+		WithIndexTableNameStrip("_view$"),
+		WithIndexSoftDeleteColumn("removed_at"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, baselineHooks, len(ex.Hooks()),
+		"PR 1 must not wire any hook; that arrives in PR 2")
+}


### PR DESCRIPTION
## Summary

Adds the **opt-in API surface** for a forthcoming `entgql.WithIndexOutput(path)` writer that will emit Postgres index DDL matching the queries the generated GraphQL surface invites (ORDER BY, WhereInput predicates). **This PR ships only the API — no behavior change.** The writer hook lands in #20 (stacked on this PR).

Shipping the API first lets consumer schemas adopt the new `entgql.SkipIndex(...)` annotation independently of the writer flipping on.

## What's added

**New annotation** (`entgql.Annotation` field + constructor):
- `entgql.SkipIndex(modes ...SkipIndexMode)` — per-field opt-out
- `SkipIndexMode` bit flag with `SkipIndexOrder | SkipIndexEquality | SkipIndexContains | SkipAllIndexes`
- OR-fold semantics in `Annotation.Merge`

**New ExtensionOptions** (no hook wired in this PR):
- `WithIndexOutput(path string)` — destination file for generated DDL; empty disables
- `WithIndexTableNameStrip(pattern string)` — regex whose matches are deleted from `node.Table()` to derive physical table names (e.g. `"_view$"` for view-backed entities); empty disables; invalid regex errors at option-apply time
- `WithIndexSoftDeleteColumn(col string)` — column triggering partial-index emission (\`WHERE <col> IS NULL\`); defaults to \`"deleted_at"\`; empty disables (no fallback to default)

## Tests

- 6 new tests in `annotation_test.go` covering `SkipIndex` constructor variants, mode methods, `Annotation.Merge` OR-fold, and decode round-trip.
- 9 new tests in a new `extension_indexes_test.go` covering option defaults, set/reset/disable semantics, invalid regex error, custom soft-delete column, and a load-bearing "Hooks() length unchanged" assertion.
- Full `go test ./entgql/...` passes (58s).

## Stack

This is the bottom of a 2-PR stack via git-spice:
- **PR #19 (this PR) → master**
- PR #20 → PR #19 (writer + hook wiring)