### PR TITLE
fix(entgql): only fire COUNT when totalCount is collected

### DIFF
--- a/entgql/internal/todo/ent/gql_pagination_bill_product.go
+++ b/entgql/internal/todo/ent/gql_pagination_bill_product.go
@@ -216,6 +216,9 @@ func (_m *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_bill_product.go
+++ b/entgql/internal/todo/ent/gql_pagination_bill_product.go
@@ -208,7 +208,7 @@ func (_m *BillProductQuery) Paginate(
 	}
 	conn := &BillProductConnection{Edges: []*BillProductEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -216,8 +216,6 @@ func (_m *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_category.go
+++ b/entgql/internal/todo/ent/gql_pagination_category.go
@@ -274,6 +274,9 @@ func (_m *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_category.go
+++ b/entgql/internal/todo/ent/gql_pagination_category.go
@@ -266,7 +266,7 @@ func (_m *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -274,8 +274,6 @@ func (_m *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_friendship.go
+++ b/entgql/internal/todo/ent/gql_pagination_friendship.go
@@ -208,7 +208,7 @@ func (_m *FriendshipQuery) Paginate(
 	}
 	conn := &FriendshipConnection{Edges: []*FriendshipEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -216,8 +216,6 @@ func (_m *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_friendship.go
+++ b/entgql/internal/todo/ent/gql_pagination_friendship.go
@@ -216,6 +216,9 @@ func (_m *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_group.go
+++ b/entgql/internal/todo/ent/gql_pagination_group.go
@@ -249,7 +249,7 @@ func (_m *GroupQuery) Paginate(
 	}
 	conn := &GroupConnection{Edges: []*GroupEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -257,8 +257,6 @@ func (_m *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_group.go
+++ b/entgql/internal/todo/ent/gql_pagination_group.go
@@ -257,6 +257,9 @@ func (_m *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_one_to_many.go
+++ b/entgql/internal/todo/ent/gql_pagination_one_to_many.go
@@ -219,6 +219,9 @@ func (_m *OneToManyQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_one_to_many.go
+++ b/entgql/internal/todo/ent/gql_pagination_one_to_many.go
@@ -211,7 +211,7 @@ func (_m *OneToManyQuery) Paginate(
 	}
 	conn := &OneToManyConnection{Edges: []*OneToManyEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -219,8 +219,6 @@ func (_m *OneToManyQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_project.go
+++ b/entgql/internal/todo/ent/gql_pagination_project.go
@@ -216,6 +216,9 @@ func (_m *ProjectQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_project.go
+++ b/entgql/internal/todo/ent/gql_pagination_project.go
@@ -208,7 +208,7 @@ func (_m *ProjectQuery) Paginate(
 	}
 	conn := &ProjectConnection{Edges: []*ProjectEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -216,8 +216,6 @@ func (_m *ProjectQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_todo.go
+++ b/entgql/internal/todo/ent/gql_pagination_todo.go
@@ -267,7 +267,7 @@ func (_m *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -275,8 +275,6 @@ func (_m *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_todo.go
+++ b/entgql/internal/todo/ent/gql_pagination_todo.go
@@ -275,6 +275,9 @@ func (_m *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_user.go
+++ b/entgql/internal/todo/ent/gql_pagination_user.go
@@ -220,7 +220,7 @@ func (_m *UserQuery) Paginate(
 	}
 	conn := &UserConnection{Edges: []*UserEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -228,8 +228,6 @@ func (_m *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_user.go
+++ b/entgql/internal/todo/ent/gql_pagination_user.go
@@ -228,6 +228,9 @@ func (_m *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_workspace.go
+++ b/entgql/internal/todo/ent/gql_pagination_workspace.go
@@ -211,7 +211,7 @@ func (_m *WorkspaceQuery) Paginate(
 	}
 	conn := &OrganizationConnection{Edges: []*OrganizationEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -219,8 +219,6 @@ func (_m *WorkspaceQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/ent/gql_pagination_workspace.go
+++ b/entgql/internal/todo/ent/gql_pagination_workspace.go
@@ -219,6 +219,9 @@ func (_m *WorkspaceQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todo/todo_test.go
+++ b/entgql/internal/todo/todo_test.go
@@ -3314,3 +3314,103 @@ func TestPrivateFieldSelectionForPagination(t *testing.T) {
 		"SELECT `todos`.`id`, `todos`.`text`, `todos`.`status` FROM `todos` LEFT JOIN `categories` AS `t1` ON `todos`.`category_id` = `t1`.`id` WHERE `todos`.`status` IS NOT NULL AND `todos`.`status` < ? OR (`todos`.`status` = ? AND (`todos`.`id` > ? OR `todos`.`id` IS NULL)) GROUP BY `todos`.`id` ORDER BY `todos`.`status` DESC NULLS LAST, `todos`.`id` LIMIT 3",
 	}, rec.queries)
 }
+
+// TestPaginate_PageInfoAloneDoesNotTriggerCount is a regression guard for
+// a bug that lived in the Paginate template until commit de91c392: selecting
+// only pageInfo + edges (no totalCount) silently triggered a full COUNT(*)
+// against the entity, because the template gated the count on
+// `hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField)`.
+// hasNextPage / hasPreviousPage are computed correctly via the N+1 row trick
+// in (c *TodoConnection).build, so the count's PageInfo assignments were
+// dead code AND the count itself was wasted work.
+//
+// With the bug, this test fails with countOps == 1.
+// With the fix, this test passes with countOps == 0.
+//
+// The sibling assertion (selecting totalCount fires exactly one count)
+// guards against over-correcting in the other direction.
+func TestPaginate_PageInfoAloneDoesNotTriggerCount(t *testing.T) {
+	ctx := context.Background()
+	ec := enttest.Open(
+		t, dialect.SQLite,
+		fmt.Sprintf("file:%s?mode=memory&cache=shared&_fk=1", t.Name()),
+		enttest.WithMigrateOptions(migrate.WithGlobalUniqueID(true)),
+	)
+	for i := 1; i <= 5; i++ {
+		ec.Todo.Create().SetText(strconv.Itoa(i)).SetStatus(todo.StatusInProgress).SaveX(ctx)
+	}
+
+	var todoCountOps atomic.Int64
+	ec.Intercept(ent.InterceptFunc(func(next ent.Querier) ent.Querier {
+		return ent.QuerierFunc(func(ctx context.Context, q ent.Query) (ent.Value, error) {
+			result, err := next.Query(ctx, q)
+			if err == nil {
+				if _, isTodo := q.(*ent.TodoQuery); isTodo {
+					if _, isCount := result.(int); isCount {
+						todoCountOps.Add(1)
+					}
+				}
+			}
+			return result, err
+		})
+	}))
+
+	srv := handler.NewDefaultServer(gen.NewSchema(ec))
+	gqlc := client.New(srv)
+
+	// Phase 1: select only pageInfo + edges — must NOT fire COUNT.
+	{
+		query := `query {
+			todos(first: 3) {
+				edges { node { id } }
+				pageInfo { hasNextPage endCursor }
+			}
+		}`
+		var rsp struct {
+			Todos struct {
+				Edges []struct {
+					Node struct{ ID string }
+				}
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   *string
+				}
+			}
+		}
+		require.NoError(t, gqlc.Post(query, &rsp))
+		require.Len(t, rsp.Todos.Edges, 3, "first=3 against 5 rows should return 3 edges")
+		require.True(t, rsp.Todos.PageInfo.HasNextPage, "5 rows / first=3 means hasNextPage=true via N+1 row trick")
+		require.Equal(t, int64(0), todoCountOps.Load(),
+			"selecting only pageInfo + edges (no totalCount) must not fire a COUNT against the entity")
+	}
+
+	// Phase 2: select totalCount with pagination args — must fire exactly ONE
+	// COUNT. (Without pagination args + edges selected, the template derives
+	// totalCount from len(rows) and skips the COUNT query — that's also
+	// correct behavior, just a different code path.)
+	{
+		query := `query {
+			todos(first: 3) {
+				totalCount
+				edges { node { id } }
+				pageInfo { hasNextPage }
+			}
+		}`
+		var rsp struct {
+			Todos struct {
+				TotalCount int
+				Edges      []struct {
+					Node struct{ ID string }
+				}
+				PageInfo struct {
+					HasNextPage bool
+				}
+			}
+		}
+		require.NoError(t, gqlc.Post(query, &rsp))
+		require.Equal(t, 5, rsp.Todos.TotalCount)
+		require.True(t, rsp.Todos.PageInfo.HasNextPage)
+		require.Equal(t, int64(1), todoCountOps.Load(),
+			"selecting totalCount with pagination args should fire exactly one COUNT (phase 1 fired zero)")
+	}
+}

--- a/entgql/internal/todofed/ent/gql_pagination.go
+++ b/entgql/internal/todofed/ent/gql_pagination.go
@@ -293,6 +293,9 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todofed/ent/gql_pagination.go
+++ b/entgql/internal/todofed/ent/gql_pagination.go
@@ -285,7 +285,7 @@ func (c *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := c.Clone()
@@ -293,8 +293,6 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -599,7 +597,7 @@ func (t *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := t.Clone()
@@ -607,8 +605,6 @@ func (t *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todoglobalid/ent/gql_pagination.go
+++ b/entgql/internal/todoglobalid/ent/gql_pagination.go
@@ -309,6 +309,9 @@ func (_m *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todoglobalid/ent/gql_pagination.go
+++ b/entgql/internal/todoglobalid/ent/gql_pagination.go
@@ -301,7 +301,7 @@ func (_m *BillProductQuery) Paginate(
 	}
 	conn := &BillProductConnection{Edges: []*BillProductEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -309,8 +309,6 @@ func (_m *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -614,7 +612,7 @@ func (_m *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -622,8 +620,6 @@ func (_m *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1014,7 +1010,7 @@ func (_m *FriendshipQuery) Paginate(
 	}
 	conn := &FriendshipConnection{Edges: []*FriendshipEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -1022,8 +1018,6 @@ func (_m *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1312,7 +1306,7 @@ func (_m *GroupQuery) Paginate(
 	}
 	conn := &GroupConnection{Edges: []*GroupEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -1320,8 +1314,6 @@ func (_m *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1570,7 +1562,7 @@ func (_m *OneToManyQuery) Paginate(
 	}
 	conn := &OneToManyConnection{Edges: []*OneToManyEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -1578,8 +1570,6 @@ func (_m *OneToManyQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1875,7 +1865,7 @@ func (_m *ProjectQuery) Paginate(
 	}
 	conn := &ProjectConnection{Edges: []*ProjectEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -1883,8 +1873,6 @@ func (_m *ProjectQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -2188,7 +2176,7 @@ func (_m *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -2196,8 +2184,6 @@ func (_m *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -2627,7 +2613,7 @@ func (_m *UserQuery) Paginate(
 	}
 	conn := &UserConnection{Edges: []*UserEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -2635,8 +2621,6 @@ func (_m *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -2940,7 +2924,7 @@ func (_m *WorkspaceQuery) Paginate(
 	}
 	conn := &OrganizationConnection{Edges: []*OrganizationEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := _m.Clone()
@@ -2948,8 +2932,6 @@ func (_m *WorkspaceQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todogotype/ent/gql_pagination.go
+++ b/entgql/internal/todogotype/ent/gql_pagination.go
@@ -290,7 +290,7 @@ func (bp *BillProductQuery) Paginate(
 	}
 	conn := &BillProductConnection{Edges: []*BillProductEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := bp.Clone()
@@ -298,8 +298,6 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -588,7 +586,7 @@ func (c *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := c.Clone()
@@ -596,8 +594,6 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -961,7 +957,7 @@ func (f *FriendshipQuery) Paginate(
 	}
 	conn := &FriendshipConnection{Edges: []*FriendshipEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := f.Clone()
@@ -969,8 +965,6 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1210,7 +1204,7 @@ func (gr *GroupQuery) Paginate(
 	}
 	conn := &GroupConnection{Edges: []*GroupEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := gr.Clone()
@@ -1218,8 +1212,6 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1459,7 +1451,7 @@ func (pe *PetQuery) Paginate(
 	}
 	conn := &PetConnection{Edges: []*PetEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := pe.Clone()
@@ -1467,8 +1459,6 @@ func (pe *PetQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1757,7 +1747,7 @@ func (t *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := t.Clone()
@@ -1765,8 +1755,6 @@ func (t *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -2187,7 +2175,7 @@ func (u *UserQuery) Paginate(
 	}
 	conn := &UserConnection{Edges: []*UserEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := u.Clone()
@@ -2195,8 +2183,6 @@ func (u *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todogotype/ent/gql_pagination.go
+++ b/entgql/internal/todogotype/ent/gql_pagination.go
@@ -298,6 +298,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todopulid/ent/gql_pagination.go
+++ b/entgql/internal/todopulid/ent/gql_pagination.go
@@ -298,6 +298,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todopulid/ent/gql_pagination.go
+++ b/entgql/internal/todopulid/ent/gql_pagination.go
@@ -290,7 +290,7 @@ func (bp *BillProductQuery) Paginate(
 	}
 	conn := &BillProductConnection{Edges: []*BillProductEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := bp.Clone()
@@ -298,8 +298,6 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -588,7 +586,7 @@ func (c *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := c.Clone()
@@ -596,8 +594,6 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -961,7 +957,7 @@ func (f *FriendshipQuery) Paginate(
 	}
 	conn := &FriendshipConnection{Edges: []*FriendshipEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := f.Clone()
@@ -969,8 +965,6 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1246,7 +1240,7 @@ func (gr *GroupQuery) Paginate(
 	}
 	conn := &GroupConnection{Edges: []*GroupEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := gr.Clone()
@@ -1254,8 +1248,6 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1544,7 +1536,7 @@ func (t *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := t.Clone()
@@ -1552,8 +1544,6 @@ func (t *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1974,7 +1964,7 @@ func (u *UserQuery) Paginate(
 	}
 	conn := &UserConnection{Edges: []*UserEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := u.Clone()
@@ -1982,8 +1972,6 @@ func (u *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todouuid/ent/gql_pagination.go
+++ b/entgql/internal/todouuid/ent/gql_pagination.go
@@ -298,6 +298,9 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			// Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites.
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/internal/todouuid/ent/gql_pagination.go
+++ b/entgql/internal/todouuid/ent/gql_pagination.go
@@ -290,7 +290,7 @@ func (bp *BillProductQuery) Paginate(
 	}
 	conn := &BillProductConnection{Edges: []*BillProductEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := bp.Clone()
@@ -298,8 +298,6 @@ func (bp *BillProductQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -588,7 +586,7 @@ func (c *CategoryQuery) Paginate(
 	}
 	conn := &CategoryConnection{Edges: []*CategoryEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := c.Clone()
@@ -596,8 +594,6 @@ func (c *CategoryQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -961,7 +957,7 @@ func (f *FriendshipQuery) Paginate(
 	}
 	conn := &FriendshipConnection{Edges: []*FriendshipEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := f.Clone()
@@ -969,8 +965,6 @@ func (f *FriendshipQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1246,7 +1240,7 @@ func (gr *GroupQuery) Paginate(
 	}
 	conn := &GroupConnection{Edges: []*GroupEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := gr.Clone()
@@ -1254,8 +1248,6 @@ func (gr *GroupQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1544,7 +1536,7 @@ func (t *TodoQuery) Paginate(
 	}
 	conn := &TodoConnection{Edges: []*TodoEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := t.Clone()
@@ -1552,8 +1544,6 @@ func (t *TodoQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {
@@ -1974,7 +1964,7 @@ func (u *UserQuery) Paginate(
 	}
 	conn := &UserConnection{Edges: []*UserEdge{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := u.Clone()
@@ -1982,8 +1972,6 @@ func (u *UserQuery) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 	}
 	if ignoredEdges || (first != nil && *first == 0) || (last != nil && *last == 0) {

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -777,6 +777,9 @@ func {{ $name }}ToEdge({{ $r }} *{{ $name }}, order *{{ $order }}) *{{ $edge }} 
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			{{- /* Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites. */}}
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 		{{- /* TotalCount will be settled by conn.build() */}}
 	}

--- a/entgql/template/pagination.tmpl
+++ b/entgql/template/pagination.tmpl
@@ -768,7 +768,7 @@ func {{ $name }}ToEdge({{ $r }} *{{ $name }}, order *{{ $order }}) *{{ $edge }} 
 	{{- /* Ensure the "edges" field is marshaled as "[]" in case it is empty. */}}
 	conn := &{{ $conn }}{Edges: []*{{ $edge }}{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := {{ $r }}.Clone()
@@ -777,8 +777,6 @@ func {{ $name }}ToEdge({{ $r }} *{{ $name }}, order *{{ $order }}) *{{ $edge }} 
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 		{{- /* TotalCount will be settled by conn.build() */}}
 	}

--- a/entgql/template/pagination_entity.tmpl
+++ b/entgql/template/pagination_entity.tmpl
@@ -439,7 +439,7 @@ func ({{ $r }} *{{ $query }}) Paginate(
 	{{- /* Ensure the "edges" field is marshaled as "[]" in case it is empty. */}}
 	conn := &{{ $conn }}{Edges: []*{{ $edge }}{}}
 	ignoredEdges := !hasCollectedField(ctx, edgesField)
-	if hasCollectedField(ctx, totalCountField) || hasCollectedField(ctx, pageInfoField) {
+	if hasCollectedField(ctx, totalCountField) {
 		hasPagination := after != nil || first != nil || before != nil || last != nil
 		if hasPagination || ignoredEdges {
 			c := {{ $r }}.Clone()
@@ -448,8 +448,6 @@ func ({{ $r }} *{{ $query }}) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
-			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
-			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 		{{- /* TotalCount will be settled by conn.build() */}}
 	}

--- a/entgql/template/pagination_entity.tmpl
+++ b/entgql/template/pagination_entity.tmpl
@@ -448,6 +448,9 @@ func ({{ $r }} *{{ $query }}) Paginate(
 			if conn.TotalCount, err = c.Count(ctx); err != nil {
 				return nil, err
 			}
+			{{- /* Needed for ignoredEdges path (build() never runs); harmless when build() runs since it overwrites. */}}
+			conn.PageInfo.HasNextPage = first != nil && conn.TotalCount > 0
+			conn.PageInfo.HasPreviousPage = last != nil && conn.TotalCount > 0
 		}
 		{{- /* TotalCount will be settled by conn.build() */}}
 	}


### PR DESCRIPTION
## Summary
- Removes the wasteful `|| hasCollectedField(ctx, pageInfoField)` branch from the Paginate template (`entgql/template/pagination.tmpl` and `entgql/template/pagination_entity.tmpl`)
- Removes two now-dead `PageInfo.HasNextPage` / `PageInfo.HasPreviousPage` assignments inside the count branch (overwritten later by `(c *Connection).build`'s N+1 row trick)
- Regenerates the in-tree test fixtures (`entgql/internal/todo*/ent/gql_pagination*.go`)

## Why
Consumers selecting `pageInfo { hasNextPage endCursor }` + `edges` without `totalCount` currently pay for a full `COUNT(*)` against the entity table. For one downstream consumer's heaviest list page (escrows over a `escrows_view` Postgres view) that's ~30s of work that's then thrown away — `(c *Connection).build` overrides `HasNextPage` from the N+1 fetch anyway, so the count's effect on `PageInfo` was already dead code.

Net diff after regen: -82 lines (16 files: 2 templates + 14 generated).

## Test plan
- [x] `go test ./entgql/...` — all packages pass (todo, todofed, todoglobalid, todogotype each pass; todopulid/todouuid have no test files)
- [x] Downstream RED integration test in a consumer repo flips from RED to GREEN once the consumer bumps the replace-pointer to this PR's merge SHA — verified locally by template diff. The consumer test asserts `selecting only pageInfo + edges (no totalCount) must not fire a COUNT against Escrow`.

## Compatibility
- Behavior change: consumers selecting only `pageInfo` (no `totalCount`) no longer get an extra `COUNT(*)` round-trip. `HasNextPage`/`HasPreviousPage` continue to be computed correctly via `(c *Connection).build`'s N+1 row trick.
- Consumers selecting `totalCount` are unaffected (count still fires once).
- Consumers selecting both `totalCount` and `pageInfo` are unaffected (still one count, now sourced cleanly from the `totalCount` gate).