### PR TITLE
entgql: collapse where_input predicate accumulators via wherehelpers

### DIFF
--- a/entgql/template/where_input_subpkg.tmpl
+++ b/entgql/template/where_input_subpkg.tmpl
@@ -32,6 +32,7 @@ import (
     "fmt"
 
     entsql "entgo.io/ent/dialect/sql"
+    "entgo.io/ent/runtime/wherehelpers"
     "{{ $.Config.Package }}/predicate"
     "{{ $.Config.Package }}/{{ $n.Package }}"
     {{- /* Import edge type packages for edge predicates */}}
@@ -188,19 +189,15 @@ func (i *{{ $input }}) P() (predicate.{{ $n.Name }}, error) {
                 {{- $field = $f.StructField }}
             {{- end }}
             {{- if $op.Niladic }}
-                if i.{{ $field }} {
-                    predicates = append(predicates, {{ $n.Package }}.{{ $func }}())
-                }
+                predicates = wherehelpers.AppendBool(predicates, i.{{ $field }}, {{ $n.Package }}.{{ $func }})
+            {{- else if $op.Variadic }}
+                predicates = wherehelpers.AppendSlice(predicates, i.{{ $field }}, {{ $n.Package }}.{{ $func }})
+            {{- else if $f.Type.RType.IsPtr }}
+                {{- /* Field's underlying type is already a pointer-like (map/slice/etc).
+                       Wrap with a function literal so AppendPtr's deref produces the right type. */}}
+                predicates = wherehelpers.AppendPtr(predicates, i.{{ $field }}, func(v {{ $f.Type.String }}) predicate.{{ $n.Name }} { return {{ $n.Package }}.{{ $func }}(v) })
             {{- else }}
-                {{- if $op.Variadic }}
-                    if len(i.{{ $field }}) > 0 {
-                        predicates = append(predicates, {{ $n.Package }}.{{ $func }}(i.{{ $field }}...))
-                    }
-                {{- else }}
-                    if i.{{ $field }} != nil {
-                        predicates = append(predicates, {{ $n.Package }}.{{ $func }}({{ if not $f.Type.RType.IsPtr }}*{{ end }}i.{{ $field }}))
-                    }
-                {{- end }}
+                predicates = wherehelpers.AppendPtr(predicates, i.{{ $field }}, {{ $n.Package }}.{{ $func }})
             {{- end }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
## End-result bench diff (consumer cold build vs PR C baseline)

| Metric | PR C | Lever W | Delta |
|---|---|---|---|
| Total wall | 3:06.83 | **2:54.71** | **−12.1s (−6.5%)** |
| whereinputs compile | 24.9s | **5.20s** | **−79%** |
| whereinputs LOC | 136,454 | 90,809 | **−33%** |

Tests pass identically (2200/17/0). Memory neutral.

## Summary

Companion to `MatthewsREIS/ent` PR #9 (codegen-reduction PR E). Updates `entgql/template/where_input_subpkg.tmpl` so the per-field-per-operator emission switches from 3-line `if X != nil { append }` blocks to single-line `wherehelpers.AppendXxx` calls.

## Diff

One template, 21 lines changed (9 added, 12 removed). The three operator branches (Niladic / Variadic / Comparable) each collapse to one line. The rare `IsPtr=true` case wraps with a function literal so AppendPtr's dereference produces the right underlying type.

## Why

Recon on consumer's `gen/whereinputs/` showed each file has ~1K nil-check accumulator blocks of identical shape — exactly the boilerplate pattern PR 4/5 collapsed for queries and mutations via generic builders. This brings the same collapse to where_input emission.

## Dependencies

Requires `entgo.io/ent/runtime/wherehelpers` to be available (added in `MatthewsREIS/ent` #9).

## Test plan

- [x] `go test ./entgql/` — entgql package tests pass (174s)
- [ ] entgql in-repo fixtures (todouuid etc.) — pre-existing PR C migration breakage in `ent.resolvers.go` blocks fixture regen; not caused by this PR. Verified via consumer regen + build + test instead.
- [x] Consumer `MatthewsREIS/gemini` builds + tests against this branch's pseudo-version (see PR #3902 4th commit).

## Notes

- WhereInput struct field shape unchanged → no GraphQL contract change.
- The IsPtr=true branch is unused in the bench consumer but kept in the template for entgql fixtures that may have map-typed fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)