### PR TITLE
entgql: fix unkeyed struct literal in node_shared template

### DIFF
--- a/entgql/template/node_shared.tmpl
+++ b/entgql/template/node_shared.tmpl
@@ -47,7 +47,7 @@ type Noder interface {
 	IsNode()
 }
 
-var errNodeInvalidID = &NotFoundError{"node"}
+var errNodeInvalidID = &NotFoundError{Label: "node"}
 
 // NodeOption allows configuring the Noder execution using functional options.
 type NodeOption func(*nodeOptions)


### PR DESCRIPTION
## Summary

Companion to c5530ad3 (which fixed `node.tmpl`). The split-package node template `node_shared.tmpl` still emitted an unkeyed `NotFoundError` literal:

```go
var errNodeInvalidID = &NotFoundError{"node"}
```

`go vet` flags this as "composite literal uses unkeyed fields". Every consumer using the split-package layout (where `NotFoundError` lives in an `internal/types.go` subpackage with an exported `Label` field) inherits the warning in its generated `gql_node.go` — including the gemini `service-api-go` gen package.

Fix uses the keyed form:

```go
var errNodeInvalidID = &NotFoundError{Label: "node"}
```

`Label:` (capitalized) is correct for the split-package variant — `node.tmpl`'s sibling fix uses lowercase `label:` because that variant's `NotFoundError` is in-package with an unexported field.

## Scope

Template-only, matching the c5530ad3 convention — no test-entity regeneration. Regenerating locally balloons the diff to 300+ files due to codegen-version drift against the checked-in fixtures, which would obscure the one-line fix.

## Downstream

Once merged, the gemini repo bumps its `entgo.io/contrib` `replace` pseudo-version to pick this up, clearing the corresponding `go vet` finding there (MatthewsREIS/gemini#3987).